### PR TITLE
Updated python-version to 3.8

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 2.7
+        python-version: 3.8
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
`setup-python` no longer supports `python-2.7` and `myADS` currently runs in `python3` when deployed so this action needs to be updated accordingly.