### PR TITLE
Fixing the ? bug

### DIFF
--- a/myadsp/tests/test_utils.py
+++ b/myadsp/tests/test_utils.py
@@ -172,7 +172,7 @@ class TestmyADSCelery(unittest.TestCase):
         }, doseq=True)
         query_url = self.app._config.get('QUERY_ENDPOINT') % query_args
 
-        query_url = query_url + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url = query_url + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
         self.assertEqual(results, [{'name': myADSsetup['name'],
                                     'query_url': query_url,
                                     'results': [{u'arxiv_id': u'arXiv:1234:5678',
@@ -241,7 +241,7 @@ class TestmyADSCelery(unittest.TestCase):
                          format(quote_plus('bibstem:arxiv (arxiv_class:(astro-ph.*) (AGN)) '
                                            'entdate:["{0}Z00:00" TO "{1}Z23:59"] pubdate:[{2}-00 TO *]'.format(start, end, start_year)),
                                 quote_plus("score desc, bibcode desc"))
-        query_url = query_url + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url = query_url + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
         self.assertEqual(results, [{'name': myADSsetup['name'],
                                     'query': 'bibstem:arxiv (arxiv_class:(astro-ph.*) (AGN)) '
                                              'entdate:["{0}Z00:00" TO "{1}Z23:59"] pubdate:[{2}-00 TO *]'.format(start, end, start_year),
@@ -334,7 +334,9 @@ class TestmyADSCelery(unittest.TestCase):
         query_url = 'https://ui.adsabs.harvard.edu/search?q={0}&sort={1}'.\
                          format(quote_plus('citations(author:Kurtz OR author:"Kurtz, M.")'),
                                 quote_plus("entry_date desc, bibcode desc"))
-        query_url = query_url + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url = query_url + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+
+        breakpoint()
         self.assertEqual(results, [{'name': 'Test Query - citations (Citations: 161491)',
                                     'query': 'citations(author:Kurtz OR author:"Kurtz, M.")',
                                     'query_url': query_url,
@@ -396,7 +398,7 @@ class TestmyADSCelery(unittest.TestCase):
         query_url = 'https://ui.adsabs.harvard.edu/search?q={0}&sort={1}'.\
                          format(quote_plus('author:Kurtz entdate:["{0}Z00:00" TO "{1}Z23:59"] pubdate:[{2}-00 TO *]'.format(start, end, start_year)),
                                 quote_plus("score desc, bibcode desc"))
-        query_url = query_url + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url = query_url + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
         self.assertEqual(results, [{'name': myADSsetup['name'],
                                     'query': 'author:Kurtz entdate:["{0}Z00:00" TO "{1}Z23:59"] pubdate:[{2}-00 TO *]'.format(start, end, start_year),
                                     'query_url': query_url,
@@ -521,15 +523,15 @@ class TestmyADSCelery(unittest.TestCase):
         query_url1 = 'https://ui.adsabs.harvard.edu/search?q={0}&sort={1}'.\
                          format(quote_plus('AGN arxiv_class:(astro-ph.* OR physics.space-ph) entdate:["{0}Z00:00" TO "{1}Z23:59"] pubdate:[{2}-00 TO *]'.format(start, end, start_year)),
                                 quote_plus("entry_date desc, bibcode desc"))
-        query_url1 = query_url1 + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url1 = query_url1 + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
         query_url2 = 'https://ui.adsabs.harvard.edu/search?q={0}&sort={1}'.\
                          format(quote_plus('trending(AGN arxiv_class:(astro-ph.* OR physics.space-ph))'),
                                 quote_plus("score desc, bibcode desc"))
-        query_url2 = query_url2 + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url2 = query_url2 + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
         query_url3 = 'https://ui.adsabs.harvard.edu/search?q={0}&sort={1}'.\
                          format(quote_plus('useful(AGN arxiv_class:(astro-ph.* OR physics.space-ph))'),
                                 quote_plus("score desc, bibcode desc"))
-        query_url3 = query_url3 + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        query_url3 = query_url3 + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
         self.assertEqual(results, [{'name': 'Test Query - keywords - Recent Papers',
                                     'query': 'AGN arxiv_class:(astro-ph.* OR physics.space-ph) entdate:["{0}Z00:00" TO "{1}Z23:59"] pubdate:[{2}-00 TO *]'.format(start, end, start_year),
                                     'query_url': query_url1,

--- a/myadsp/tests/test_utils.py
+++ b/myadsp/tests/test_utils.py
@@ -336,7 +336,6 @@ class TestmyADSCelery(unittest.TestCase):
                                 quote_plus("entry_date desc, bibcode desc"))
         query_url = query_url + '&utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
 
-        breakpoint()
         self.assertEqual(results, [{'name': 'Test Query - citations (Citations: 161491)',
                                     'query': 'citations(author:Kurtz OR author:"Kurtz, M.")',
                                     'query_url': query_url,

--- a/myadsp/utils.py
+++ b/myadsp/utils.py
@@ -194,8 +194,21 @@ def get_template_query_results(myADSsetup, scix_ui=False):
                 name[i] = name[i] % int(cites_r.json()['stats']['stats_fields']['citation_count']['sum'])
         
         ui_endpoint = config.get('SCIX_UI_ENDPOINT') if scix_ui else config.get('UI_ENDPOINT')
-        query_url = query.replace(config.get('API_SOLR_QUERY_ENDPOINT') + '?', ui_endpoint + '/search?') \
-                    + '?utm_source=myads&utm_medium=email&utm_campaign=type:{0}&utm_term={1}&utm_content=queryurl'
+        
+        query_url = query.replace(
+                config.get('API_SOLR_QUERY_ENDPOINT') + '?',
+                ui_endpoint + '/search?'
+            )
+
+        utm_params = (
+            "utm_source=myads&utm_medium=email&utm_campaign=type:{0}"
+            "&utm_term={1}&utm_content=queryurl"
+        )
+
+        # Append with correct separator
+        separator = '&' if '?' in query_url else '?'
+        query_url = f"{query_url}{separator}{utm_params}"
+
         payload.append({'name': name[i], 'query_url': query_url, 'query': myADSsetup['query'][i]['q'], 'results': docs})
 
     return payload

--- a/myadsp/utils.py
+++ b/myadsp/utils.py
@@ -205,7 +205,6 @@ def get_template_query_results(myADSsetup, scix_ui=False):
             "&utm_term={1}&utm_content=queryurl"
         )
 
-        # Append with correct separator
         separator = '&' if '?' in query_url else '?'
         query_url = f"{query_url}{separator}{utm_params}"
 


### PR DESCRIPTION
User commented that myADS notification links were broken. 

Here's an example: 
https://ui.adsabs.harvard.edu/search?q=%22massive+stars%22+entdate%3A%5B%222025-10-20Z00%3A00%22+TO+%222025-10-28Z23%3A59%22%5D+pubdate%3A%5B2025-00+TO+%2A%5D&sort=entry_date+desc%2C+date+desc?utm_source=myads&utm_medium=email&utm_campaign=type:keyword&utm_term=1545&utm_content=queryurl

This link contains two "?". The fix is just replacing the second "?" when necessary. 

https://ui.adsabs.harvard.edu/search?q=%22massive+stars%22+entdate%3A%5B%222025-10-20Z00%3A00%22+TO+%222025-10-28Z23%3A59%22%5D+pubdate%3A%5B2025-00+TO+%2A%5D&sort=entry_date+desc%2C+date+desc&utm_source=myads&utm_medium=email&utm_campaign=type:keyword&utm_term=1545&utm_content=queryurl
